### PR TITLE
Fix highlight error when &colorcolumn was not set

### DIFF
--- a/autoload/braceless/highlight.vim
+++ b/autoload/braceless/highlight.vim
@@ -16,7 +16,7 @@ function! s:highlight_line(line1, line2)
   let [_, indent_len] = braceless#indent#space(a:line1, 0)
 
   if use_cc > 0
-    let &l:cc = b:braceless.orig_cc.','.(indent_len+1)
+    let &l:cc = (b:braceless.orig_cc != '' ? b:braceless.orig_cc.',' : '').(indent_len+1)
     if use_cc == 1
       return
     endif


### PR DESCRIPTION
Hi,

I fixed highlight error when `&colorcolumn` hasn't been set and `:BracelessEnable +highlight-cc`

In this case, `&l:cc` is set as `,3` (3 is just example) but this value is invalid.
So I removed comma when `&colorcolumn` is not set in global.
