### PR TITLE
Build vim from source on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: vim
 
-before_script: make .test/plugins
+before_script: |
+  git clone https://github.com/vim/vim
+  cd vim
+  git checkout v7.4.052
+  ./configure --with-features=huge
+  make -j4
+  sudo make install
+  cd -
+  make .test/plugins
 
 script: make test


### PR DESCRIPTION
Taken from: https://github.com/junegunn/vim-oblique/blob/master/.travis.yml

v7.4.052 is chosen because that's what I'm currently using for testing
(Ubuntu 14.04.3 LTS).
