### PR TITLE
Drop redundant g] and g[ mappings

### DIFF
--- a/doc/braceless.txt
+++ b/doc/braceless.txt
@@ -225,11 +225,8 @@ Default:
 *g:braceless_jump_prev_key*
 *g:braceless_jump_next_key*
 
-By default, these let you move around using the |[[| and |]]| keys.  The following
-sequences are also mapped with these keys:
-
-  *g]*    Move forward to an increased indent level
-  *g[*    Move backward to a decreased indent level
+By default you can move between block heads using the |[[| and |]]| motions.
+This fits better with VIM's traditional notion of a |section|.
 
 Default:
 >
@@ -239,6 +236,15 @@ Default:
 
 *g:braceless_segment_prev_key*
 *g:braceless_segment_next_key*
+
+You can enable motions for moving between block indent levels using
+|g[| and |g]|.
+
+Default:
+>
+  let g:braceless_enable_jump_indent = 1
+<
+*g:braceless_enable_jump_indent*
 
 Keys used for moving between segments.
 

--- a/plugin/braceless.vim
+++ b/plugin/braceless.vim
@@ -54,15 +54,18 @@ function! s:enable(...)
 
   if !empty(g:braceless#key#jump_prev)
     execute 'map <buffer> ['.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-n)'
-    execute 'map <buffer> g'.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-n-indent)'
     execute 'vmap <buffer> ['.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-v)'
-    execute 'vmap <buffer> g'.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-v-indent)'
   endif
 
   if !empty(g:braceless#key#jump_next)
     execute 'map <buffer> ]'.g:braceless#key#jump_next.' <Plug>(braceless-jump-next-n)'
-    execute 'map <buffer> g'.g:braceless#key#jump_next.' <Plug>(braceless-jump-next-n-indent)'
     execute 'vmap <buffer> ]'.g:braceless#key#jump_next.' <Plug>(braceless-jump-next-v)'
+  endif
+
+  if get(g:, 'braceless_enable_jump_indent', 0)
+    execute 'map <buffer> g'.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-n-indent)'
+    execute 'vmap <buffer> g'.g:braceless#key#jump_prev.' <Plug>(braceless-jump-prev-v-indent)'
+    execute 'map <buffer> g'.g:braceless#key#jump_next.' <Plug>(braceless-jump-next-n-indent)'
     execute 'vmap <buffer> g'.g:braceless#key#jump_next.' <Plug>(braceless-jump-next-v-indent)'
   endif
 


### PR DESCRIPTION
These motions are redundant (since [[ and ]] are already used) and
also mask other standard mappings (eg. g] normally is shorthand for
:tselect). Adjust the docs to match.

Fixes #37