### PR TITLE
Fix jumping to 'def' and 'class' inside words using ]m

### DIFF
--- a/autoload/braceless/python.vim
+++ b/autoload/braceless/python.vim
@@ -272,7 +272,7 @@ function! s:indent_handler.docstring(line, docstr)
   throw 'cont'
 endfunction
 
-let s:jump = '^\s*\%(def\|class\)\s*\zs\S\_.\{-}:\ze\s*\%(\_$\|#\)'
+let s:jump = '^\s*\%(\<def\>\|\<class\>\)\s*\zs\S\_.\{-}:\ze\s*\%(\_$\|#\)'
 
 function! <SID>braceless_method_jump(vmode, direction, top)
   if a:vmode ==? 'v'


### PR DESCRIPTION
When a variable is declared starting with *def* or *class* the **]m** and **[m** commands jump to wrong location.

i.e.:
```
def foo:
    default = 0 #  ]m would jump to here
    classic = 0 #  same here
```